### PR TITLE
Implement Basic Functionalities for the Query Module

### DIFF
--- a/lib/rdf-borsh/src/borsh_reader.rs
+++ b/lib/rdf-borsh/src/borsh_reader.rs
@@ -69,7 +69,15 @@ impl<R: Read> Reader for BorshReader<R> {
 }
 
 impl<R: Read> Source for BorshReader<R> {}
-impl<R: Read> Enumerable for BorshReader<R> {}
+
+impl<R: Read> Enumerable for BorshReader<R> {
+    fn grep(&self, pattern: &impl PartialEq<Box<dyn Statement>>) -> Self
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+}
 impl<R: Read> MaybeDurable for BorshReader<R> {}
 impl<R: Read> MaybeIndexed for BorshReader<R> {}
 impl<R: Read> MaybeMutable for BorshReader<R> {}

--- a/lib/rdf-model/src/lib.rs
+++ b/lib/rdf-model/src/lib.rs
@@ -69,9 +69,6 @@ mod traits {
 
     mod maybe_mutable;
     pub use maybe_mutable::*;
-
-    mod queryable;
-    pub use queryable::*;
 }
 pub use traits::*;
 

--- a/lib/rdf-model/src/traits/enumerable.rs
+++ b/lib/rdf-model/src/traits/enumerable.rs
@@ -10,4 +10,7 @@ use core::error::Error;
 pub trait Enumerable:
     Countable + Iterator<Item = Result<Box<dyn Statement>, Box<dyn Error>>>
 {
+    fn grep(&self, pattern: &impl PartialEq<Box<dyn Statement>>) -> Self
+    where
+        Self: Sized;
 }

--- a/lib/rdf-model/src/traits/queryable.rs
+++ b/lib/rdf-model/src/traits/queryable.rs
@@ -1,5 +1,0 @@
-// This is free and unencumbered software released into the public domain.
-
-use super::Enumerable;
-
-pub trait Queryable: Enumerable {}

--- a/lib/rdf-query/src/graph_pattern.rs
+++ b/lib/rdf-query/src/graph_pattern.rs
@@ -1,0 +1,18 @@
+use crate::{pattern::Pattern, query::Query};
+
+pub enum GraphPattern {
+    BasicGraphPattern(Query),
+    TriplePattern(Pattern),
+}
+
+impl From<Query> for GraphPattern {
+    fn from(query: Query) -> Self {
+        Self::BasicGraphPattern(query)
+    }
+}
+
+impl From<Pattern> for GraphPattern {
+    fn from(pattern: Pattern) -> Self {
+        Self::TriplePattern(pattern)
+    }
+}

--- a/lib/rdf-query/src/lib.rs
+++ b/lib/rdf-query/src/lib.rs
@@ -9,6 +9,11 @@
 
 pub mod matcher;
 pub mod pattern;
+pub mod query;
 pub mod solution;
 pub mod solutions;
 pub mod variable;
+
+mod traits {
+    pub mod queryable;
+}

--- a/lib/rdf-query/src/lib.rs
+++ b/lib/rdf-query/src/lib.rs
@@ -6,3 +6,8 @@
 
 #![no_std]
 #![deny(unsafe_code)]
+
+pub mod pattern;
+pub mod solution;
+pub mod solutions;
+pub mod variable;

--- a/lib/rdf-query/src/lib.rs
+++ b/lib/rdf-query/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 #![deny(unsafe_code)]
 
+pub mod graph_pattern;
 pub mod matcher;
 pub mod pattern;
 pub mod query;

--- a/lib/rdf-query/src/lib.rs
+++ b/lib/rdf-query/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 #![deny(unsafe_code)]
 
+pub mod matcher;
 pub mod pattern;
 pub mod solution;
 pub mod solutions;

--- a/lib/rdf-query/src/matcher.rs
+++ b/lib/rdf-query/src/matcher.rs
@@ -1,28 +1,39 @@
-use rdf_model::{HeapTerm, Term};
+extern crate alloc;
 
-use crate::variable::GenericVariable;
+use alloc::boxed::Box;
+use rdf_model::Term;
 
-pub type Matcher = GenericMatcher<HeapTerm>;
+use crate::variable::Variable;
 
-pub enum GenericMatcher<T: Term> {
-    Any,
-    Variable(GenericVariable<T>),
-    Term(T),
+pub enum Matcher {
+    Variable(Variable),
+    Term(Box<dyn Term>),
 }
 
-impl<T: Term> GenericMatcher<T> {
-    pub fn matches(&self, term: &dyn Term) -> bool {
+impl PartialEq<&dyn Term> for Matcher {
+    fn eq(&self, term: &&dyn Term) -> bool {
         match self {
-            Self::Any | Self::Variable(_) => true,
+            Self::Variable(_) => true,
             Self::Term(t) => t.as_str() == term.as_str(),
         }
     }
 }
 
-impl<T: Term + core::fmt::Debug> core::fmt::Debug for GenericMatcher<T> {
+impl From<Variable> for Matcher {
+    fn from(var: Variable) -> Self {
+        Self::Variable(var)
+    }
+}
+
+impl From<Box<dyn Term>> for Matcher {
+    fn from(term: Box<dyn Term>) -> Self {
+        Self::Term(term)
+    }
+}
+
+impl core::fmt::Debug for Matcher {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
-            Self::Any => f.write_str("Any"),
             Self::Variable(var) => write!(f, "{:?}", var),
             Self::Term(t) => f.write_str(&t.as_str()),
         }

--- a/lib/rdf-query/src/matcher.rs
+++ b/lib/rdf-query/src/matcher.rs
@@ -10,6 +10,15 @@ pub enum Matcher {
     Term(Box<dyn Term>),
 }
 
+impl Matcher {
+    pub fn as_variable(&self) -> Option<&Variable> {
+        match self {
+            Self::Variable(var) => Some(var),
+            _ => None,
+        }
+    }
+}
+
 impl PartialEq<&dyn Term> for Matcher {
     fn eq(&self, term: &&dyn Term) -> bool {
         match self {
@@ -22,6 +31,12 @@ impl PartialEq<&dyn Term> for Matcher {
 impl From<Variable> for Matcher {
     fn from(var: Variable) -> Self {
         Self::Variable(var)
+    }
+}
+
+impl From<&str> for Matcher {
+    fn from(name: &str) -> Self {
+        name.into()
     }
 }
 

--- a/lib/rdf-query/src/matcher.rs
+++ b/lib/rdf-query/src/matcher.rs
@@ -1,0 +1,30 @@
+use rdf_model::{HeapTerm, Term};
+
+use crate::variable::GenericVariable;
+
+pub type Matcher = GenericMatcher<HeapTerm>;
+
+pub enum GenericMatcher<T: Term> {
+    Any,
+    Variable(GenericVariable<T>),
+    Term(T),
+}
+
+impl<T: Term> GenericMatcher<T> {
+    pub fn matches(&self, term: &dyn Term) -> bool {
+        match self {
+            Self::Any | Self::Variable(_) => true,
+            Self::Term(t) => t.as_str() == term.as_str(),
+        }
+    }
+}
+
+impl<T: Term + core::fmt::Debug> core::fmt::Debug for GenericMatcher<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            Self::Any => f.write_str("Any"),
+            Self::Variable(var) => write!(f, "{:?}", var),
+            Self::Term(t) => f.write_str(&t.as_str()),
+        }
+    }
+}

--- a/lib/rdf-query/src/pattern.rs
+++ b/lib/rdf-query/src/pattern.rs
@@ -1,34 +1,23 @@
-use rdf_model::{HeapTerm, Statement, Term};
+extern crate alloc;
 
-use crate::{matcher::GenericMatcher, variable::GenericVariable};
+use alloc::boxed::Box;
+use rdf_model::{Statement, Term};
 
-pub type Pattern = GenericPattern<HeapTerm>;
+use crate::{matcher::Matcher, solutions::Solutions, traits::queryable::Queryable};
 
-impl<T: Term> From<GenericVariable<T>> for GenericMatcher<T> {
-    fn from(var: GenericVariable<T>) -> Self {
-        Self::Variable(var)
-    }
+pub struct Pattern {
+    subject: Matcher,
+    predicate: Matcher,
+    object: Matcher,
+    graph_name: Option<Box<dyn Term>>,
 }
 
-impl<T: Term> From<T> for GenericMatcher<T> {
-    fn from(term: T) -> Self {
-        Self::Term(term)
-    }
-}
-
-pub struct GenericPattern<T: Term> {
-    subject: GenericMatcher<T>,
-    predicate: GenericMatcher<T>,
-    object: GenericMatcher<T>,
-    graph_name: Option<T>,
-}
-
-impl<T: Term> GenericPattern<T> {
+impl Pattern {
     pub fn new(
-        subject: impl Into<GenericMatcher<T>>,
-        predicate: impl Into<GenericMatcher<T>>,
-        object: impl Into<GenericMatcher<T>>,
-        graph_name: Option<T>,
+        subject: impl Into<Matcher>,
+        predicate: impl Into<Matcher>,
+        object: impl Into<Matcher>,
+        graph_name: Option<Box<dyn Term>>,
     ) -> Self {
         Self {
             subject: subject.into(),
@@ -38,14 +27,21 @@ impl<T: Term> GenericPattern<T> {
         }
     }
 
-    pub fn matches(&self, statement: &dyn Statement) -> bool {
-        self.subject.matches(statement.subject())
-            && self.predicate.matches(statement.predicate())
-            && self.object.matches(statement.object())
+    pub(crate) fn execute(&self, queryable: &impl Queryable) -> Solutions {
+        // queryable.query_pattern(self)
+        todo!()
     }
 }
 
-impl<T: Term + core::fmt::Debug> core::fmt::Debug for GenericPattern<T> {
+impl PartialEq<Box<dyn Statement>> for Pattern {
+    fn eq(&self, statement: &Box<dyn Statement>) -> bool {
+        self.subject == statement.subject()
+            && self.predicate == statement.predicate()
+            && self.object == statement.object()
+    }
+}
+
+impl core::fmt::Debug for Pattern {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("Pattern")
             .field("graph_name", &self.graph_name)

--- a/lib/rdf-query/src/pattern.rs
+++ b/lib/rdf-query/src/pattern.rs
@@ -1,0 +1,7 @@
+pub struct Pattern {}
+
+impl core::fmt::Debug for Pattern {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Pattern").finish()
+    }
+}

--- a/lib/rdf-query/src/pattern.rs
+++ b/lib/rdf-query/src/pattern.rs
@@ -1,7 +1,7 @@
 extern crate alloc;
 
 use alloc::{boxed::Box, collections::BTreeMap};
-use rdf_model::{HeapTerm, Statement, Term};
+use rdf_model::{Statement, Term};
 
 use crate::{
     matcher::Matcher, solution::Solution, traits::queryable::Queryable, variable::Variable,
@@ -47,7 +47,7 @@ impl Pattern {
             .map(Variable::name)
             .map(Variable::unbound)
         {
-            bindings.insert(subject, HeapTerm::from(statement.subject()));
+            bindings.insert(subject, statement.subject());
         }
 
         if let Some(predicate) = self
@@ -56,7 +56,7 @@ impl Pattern {
             .map(Variable::name)
             .map(Variable::unbound)
         {
-            bindings.insert(predicate, HeapTerm::from(statement.predicate()));
+            bindings.insert(predicate, statement.predicate());
         }
 
         if let Some(object) = self
@@ -65,7 +65,7 @@ impl Pattern {
             .map(Variable::name)
             .map(Variable::unbound)
         {
-            bindings.insert(object, HeapTerm::from(statement.object()));
+            bindings.insert(object, statement.object());
         }
 
         Solution::new(bindings)

--- a/lib/rdf-query/src/pattern.rs
+++ b/lib/rdf-query/src/pattern.rs
@@ -1,23 +1,57 @@
-use rdf_model::Statement;
+use rdf_model::{HeapTerm, Statement, Term};
 
-pub struct Pattern {}
+use crate::{matcher::GenericMatcher, variable::GenericVariable};
 
-impl Statement for Pattern {
-    fn subject(&self) -> &dyn rdf_model::Term {
-        todo!()
-    }
+pub type Pattern = GenericPattern<HeapTerm>;
 
-    fn predicate(&self) -> &dyn rdf_model::Term {
-        todo!()
-    }
-
-    fn object(&self) -> &dyn rdf_model::Term {
-        todo!()
+impl<T: Term> From<GenericVariable<T>> for GenericMatcher<T> {
+    fn from(var: GenericVariable<T>) -> Self {
+        Self::Variable(var)
     }
 }
 
-impl core::fmt::Debug for Pattern {
+impl<T: Term> From<T> for GenericMatcher<T> {
+    fn from(term: T) -> Self {
+        Self::Term(term)
+    }
+}
+
+pub struct GenericPattern<T: Term> {
+    subject: GenericMatcher<T>,
+    predicate: GenericMatcher<T>,
+    object: GenericMatcher<T>,
+    graph_name: Option<T>,
+}
+
+impl<T: Term> GenericPattern<T> {
+    pub fn new(
+        subject: impl Into<GenericMatcher<T>>,
+        predicate: impl Into<GenericMatcher<T>>,
+        object: impl Into<GenericMatcher<T>>,
+        graph_name: Option<T>,
+    ) -> Self {
+        Self {
+            subject: subject.into(),
+            predicate: predicate.into(),
+            object: object.into(),
+            graph_name,
+        }
+    }
+
+    pub fn matches(&self, statement: &dyn Statement) -> bool {
+        self.subject.matches(statement.subject())
+            && self.predicate.matches(statement.predicate())
+            && self.object.matches(statement.object())
+    }
+}
+
+impl<T: Term + core::fmt::Debug> core::fmt::Debug for GenericPattern<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("Pattern").finish()
+        f.debug_struct("Pattern")
+            .field("graph_name", &self.graph_name)
+            .field("subject", &self.subject)
+            .field("predicate", &self.predicate)
+            .field("object", &self.object)
+            .finish()
     }
 }

--- a/lib/rdf-query/src/pattern.rs
+++ b/lib/rdf-query/src/pattern.rs
@@ -1,4 +1,20 @@
+use rdf_model::Statement;
+
 pub struct Pattern {}
+
+impl Statement for Pattern {
+    fn subject(&self) -> &dyn rdf_model::Term {
+        todo!()
+    }
+
+    fn predicate(&self) -> &dyn rdf_model::Term {
+        todo!()
+    }
+
+    fn object(&self) -> &dyn rdf_model::Term {
+        todo!()
+    }
+}
 
 impl core::fmt::Debug for Pattern {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/lib/rdf-query/src/query.rs
+++ b/lib/rdf-query/src/query.rs
@@ -1,0 +1,36 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use crate::{pattern::Pattern, solutions::Solutions, traits::queryable::Queryable};
+
+pub struct Query {
+    patterns: Vec<Pattern>,
+}
+
+impl Query {
+    pub fn new(patterns: Vec<Pattern>) -> Self {
+        Self { patterns }
+    }
+
+    /// Executes the query on the given graph.
+    ///
+    /// If the query nas no patterns, it returns a single empty solution as per
+    /// SPARQL 1.1 Empty Group Pattern.
+    pub fn execute(&self, queryable: impl Queryable) -> Solutions {
+        if self.empty() {
+            return Solutions::empty();
+        }
+
+        for pattern in &self.patterns {
+            let _ = pattern.execute(&queryable);
+        }
+
+        Solutions::empty()
+    }
+
+    /// Returns true if the query has no patterns.
+    pub fn empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+}

--- a/lib/rdf-query/src/solution.rs
+++ b/lib/rdf-query/src/solution.rs
@@ -1,0 +1,7 @@
+pub struct Solution {}
+
+impl core::fmt::Debug for Solution {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Solution").finish()
+    }
+}

--- a/lib/rdf-query/src/solution.rs
+++ b/lib/rdf-query/src/solution.rs
@@ -1,34 +1,34 @@
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
-use rdf_model::{HeapTerm, Term};
+use alloc::{boxed::Box, collections::BTreeMap};
+use rdf_model::Term;
 
-use crate::variable::GenericVariable;
+use crate::variable::Variable;
 
-pub type Solution = GenericSolution<HeapTerm>;
+type Value = Box<dyn Term>;
 
-pub struct GenericSolution<T: Term> {
-    bindings: BTreeMap<GenericVariable<T>, T>,
+pub struct Solution {
+    bindings: BTreeMap<Variable, Value>,
 }
 
-impl<T: Term + Ord> GenericSolution<T> {
-    pub fn new(bindings: BTreeMap<GenericVariable<T>, T>) -> Self {
+impl Solution {
+    pub fn new(bindings: BTreeMap<Variable, Value>) -> Self {
         Self { bindings }
     }
 
-    pub fn binding(&self, var: &GenericVariable<T>) -> Option<&T> {
+    pub fn binding(&self, var: &Variable) -> Option<&Value> {
         self.bindings.get(var)
     }
 
-    pub fn each_binding(&self) -> impl Iterator<Item = (&GenericVariable<T>, &T)> {
+    pub fn each_binding(&self) -> impl Iterator<Item = (&Variable, &Value)> {
         self.bindings.iter()
     }
 
-    pub fn each_name(&self) -> impl Iterator<Item = &GenericVariable<T>> {
+    pub fn each_name(&self) -> impl Iterator<Item = &Variable> {
         self.bindings.keys()
     }
 
-    pub fn each_value(&self) -> impl Iterator<Item = &T> {
+    pub fn each_value(&self) -> impl Iterator<Item = &Value> {
         self.bindings.values()
     }
 }

--- a/lib/rdf-query/src/solution.rs
+++ b/lib/rdf-query/src/solution.rs
@@ -1,4 +1,37 @@
-pub struct Solution {}
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use rdf_model::{HeapTerm, Term};
+
+use crate::variable::GenericVariable;
+
+pub type Solution = GenericSolution<HeapTerm>;
+
+pub struct GenericSolution<T: Term> {
+    bindings: BTreeMap<GenericVariable<T>, T>,
+}
+
+impl<T: Term + Ord> GenericSolution<T> {
+    pub fn new(bindings: BTreeMap<GenericVariable<T>, T>) -> Self {
+        Self { bindings }
+    }
+
+    pub fn binding(&self, var: &GenericVariable<T>) -> Option<&T> {
+        self.bindings.get(var)
+    }
+
+    pub fn each_binding(&self) -> impl Iterator<Item = (&GenericVariable<T>, &T)> {
+        self.bindings.iter()
+    }
+
+    pub fn each_name(&self) -> impl Iterator<Item = &GenericVariable<T>> {
+        self.bindings.keys()
+    }
+
+    pub fn each_value(&self) -> impl Iterator<Item = &T> {
+        self.bindings.values()
+    }
+}
 
 impl core::fmt::Debug for Solution {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/lib/rdf-query/src/solution.rs
+++ b/lib/rdf-query/src/solution.rs
@@ -1,26 +1,26 @@
 extern crate alloc;
 
-use alloc::{boxed::Box, collections::BTreeMap};
-use rdf_model::Term;
+use alloc::collections::BTreeMap;
+use rdf_model::HeapTerm;
 
 use crate::variable::Variable;
 
-type Value = Box<dyn Term>;
-
+// TODO: the use of HeapTerm might be reconsidered. The idea is that the term
+//       stored in the solution must be owned by it, and not a reference.
 pub struct Solution {
-    bindings: BTreeMap<Variable, Value>,
+    bindings: BTreeMap<Variable, HeapTerm>,
 }
 
 impl Solution {
-    pub fn new(bindings: BTreeMap<Variable, Value>) -> Self {
+    pub fn new(bindings: BTreeMap<Variable, HeapTerm>) -> Self {
         Self { bindings }
     }
 
-    pub fn binding(&self, var: &Variable) -> Option<&Value> {
+    pub fn binding(&self, var: &Variable) -> Option<&HeapTerm> {
         self.bindings.get(var)
     }
 
-    pub fn each_binding(&self) -> impl Iterator<Item = (&Variable, &Value)> {
+    pub fn each_binding(&self) -> impl Iterator<Item = (&Variable, &HeapTerm)> {
         self.bindings.iter()
     }
 
@@ -28,7 +28,7 @@ impl Solution {
         self.bindings.keys()
     }
 
-    pub fn each_value(&self) -> impl Iterator<Item = &Value> {
+    pub fn each_value(&self) -> impl Iterator<Item = &HeapTerm> {
         self.bindings.values()
     }
 }

--- a/lib/rdf-query/src/solution.rs
+++ b/lib/rdf-query/src/solution.rs
@@ -5,8 +5,6 @@ use rdf_model::HeapTerm;
 
 use crate::variable::Variable;
 
-// TODO: the use of HeapTerm might be reconsidered. The idea is that the term
-//       stored in the solution must be owned by it, and not a reference.
 pub struct Solution {
     bindings: BTreeMap<Variable, HeapTerm>,
 }

--- a/lib/rdf-query/src/solution.rs
+++ b/lib/rdf-query/src/solution.rs
@@ -12,7 +12,12 @@ pub struct Solution {
 }
 
 impl Solution {
-    pub fn new(bindings: BTreeMap<Variable, HeapTerm>) -> Self {
+    pub fn new(bindings: BTreeMap<Variable, impl Into<HeapTerm>>) -> Self {
+        let bindings = bindings
+            .into_iter()
+            .map(|(var, term)| (var, term.into()))
+            .collect();
+
         Self { bindings }
     }
 

--- a/lib/rdf-query/src/solutions.rs
+++ b/lib/rdf-query/src/solutions.rs
@@ -1,0 +1,7 @@
+pub struct Solutions {}
+
+impl core::fmt::Debug for Solutions {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Solutions").finish()
+    }
+}

--- a/lib/rdf-query/src/solutions.rs
+++ b/lib/rdf-query/src/solutions.rs
@@ -1,31 +1,36 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
-use rdf_model::Term;
 
-use crate::solution::GenericSolution;
+use crate::solution::Solution;
 
-pub struct GenericSolutions<T: Term> {
-    iter: Box<dyn Iterator<Item = GenericSolution<T>>>,
+pub struct Solutions {
+    iter: Box<dyn Iterator<Item = Solution>>,
 }
 
-impl<T: Term> GenericSolutions<T> {
-    pub fn new(iter: impl Iterator<Item = GenericSolution<T>> + 'static) -> Self {
+impl Solutions {
+    pub fn new(iter: impl Iterator<Item = Solution> + 'static) -> Self {
         Self {
             iter: Box::new(iter),
         }
     }
+
+    pub fn empty() -> Self {
+        Self {
+            iter: Box::new(core::iter::empty()),
+        }
+    }
 }
 
-impl<T: Term> Iterator for GenericSolutions<T> {
-    type Item = GenericSolution<T>;
+impl Iterator for Solutions {
+    type Item = Solution;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
 }
 
-impl<T: Term> core::fmt::Debug for GenericSolutions<T> {
+impl core::fmt::Debug for Solutions {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("Solutions").finish()
     }

--- a/lib/rdf-query/src/solutions.rs
+++ b/lib/rdf-query/src/solutions.rs
@@ -1,6 +1,31 @@
-pub struct Solutions {}
+extern crate alloc;
 
-impl core::fmt::Debug for Solutions {
+use alloc::boxed::Box;
+use rdf_model::Term;
+
+use crate::solution::GenericSolution;
+
+pub struct GenericSolutions<T: Term> {
+    iter: Box<dyn Iterator<Item = GenericSolution<T>>>,
+}
+
+impl<T: Term> GenericSolutions<T> {
+    pub fn new(iter: impl Iterator<Item = GenericSolution<T>> + 'static) -> Self {
+        Self {
+            iter: Box::new(iter),
+        }
+    }
+}
+
+impl<T: Term> Iterator for GenericSolutions<T> {
+    type Item = GenericSolution<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+impl<T: Term> core::fmt::Debug for GenericSolutions<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("Solutions").finish()
     }

--- a/lib/rdf-query/src/traits/queryable.rs
+++ b/lib/rdf-query/src/traits/queryable.rs
@@ -8,7 +8,6 @@ use crate::{pattern::Pattern, query::Query, solutions::Solutions};
 pub trait Queryable: Enumerable {
     // fn query(&self, query: GenericQuery<T>) -> GenericSolutions<T>;
 
-    // TODO: is this naming correct?
     fn query_execute(&self, query: Query) -> Solutions
     where
         Self: Sized,
@@ -16,7 +15,6 @@ pub trait Queryable: Enumerable {
         query.execute(self)
     }
 
-    // TODO: revisit this return type
     fn query_pattern(&self, pattern: &Pattern) -> Self
     where
         Self: Sized,

--- a/lib/rdf-query/src/traits/queryable.rs
+++ b/lib/rdf-query/src/traits/queryable.rs
@@ -1,24 +1,26 @@
 // This is free and unencumbered software released into the public domain.
 extern crate alloc;
 
-use alloc::boxed::Box;
-use rdf_model::{Enumerable, Statement};
+use rdf_model::Enumerable;
 
 use crate::{pattern::Pattern, query::Query, solutions::Solutions};
 
-pub trait Queryable: Enumerable + Clone {
+pub trait Queryable: Enumerable {
     // fn query(&self, query: GenericQuery<T>) -> GenericSolutions<T>;
 
-    fn query_execute(&self, query: Query) -> Solutions {
-        // query.execute(self)
-        todo!()
-    }
-
-    fn query_pattern(&self, pattern: &Pattern) -> impl Iterator<Item = Box<dyn Statement>>
+    // TODO: is this naming correct?
+    fn query_execute(&self, query: Query) -> Solutions
     where
         Self: Sized,
     {
-        self.clone() // TODO: check if the clone is necessary
-            .filter_map(move |statement| statement.ok().filter(|statement| pattern == statement))
+        query.execute(self)
+    }
+
+    // TODO: revisit this return type
+    fn query_pattern(&self, pattern: &Pattern) -> Self
+    where
+        Self: Sized,
+    {
+        self.grep(pattern)
     }
 }

--- a/lib/rdf-query/src/traits/queryable.rs
+++ b/lib/rdf-query/src/traits/queryable.rs
@@ -1,12 +1,21 @@
 // This is free and unencumbered software released into the public domain.
 extern crate alloc;
 
+use alloc::vec;
 use rdf_model::Enumerable;
 
-use crate::{pattern::Pattern, query::Query, solutions::Solutions};
+use crate::{graph_pattern::GraphPattern, pattern::Pattern, query::Query, solutions::Solutions};
 
 pub trait Queryable: Enumerable {
-    // fn query(&self, query: GenericQuery<T>) -> GenericSolutions<T>;
+    fn query(&self, pattern: impl Into<GraphPattern>) -> Solutions
+    where
+        Self: Sized,
+    {
+        match pattern.into() {
+            GraphPattern::BasicGraphPattern(query) => self.query_execute(query),
+            GraphPattern::TriplePattern(pattern) => self.query_execute(Query::new(vec![pattern])),
+        }
+    }
 
     fn query_execute(&self, query: Query) -> Solutions
     where

--- a/lib/rdf-query/src/traits/queryable.rs
+++ b/lib/rdf-query/src/traits/queryable.rs
@@ -1,0 +1,24 @@
+// This is free and unencumbered software released into the public domain.
+extern crate alloc;
+
+use alloc::boxed::Box;
+use rdf_model::{Enumerable, Statement};
+
+use crate::{pattern::Pattern, query::Query, solutions::Solutions};
+
+pub trait Queryable: Enumerable + Clone {
+    // fn query(&self, query: GenericQuery<T>) -> GenericSolutions<T>;
+
+    fn query_execute(&self, query: Query) -> Solutions {
+        // query.execute(self)
+        todo!()
+    }
+
+    fn query_pattern(&self, pattern: &Pattern) -> impl Iterator<Item = Box<dyn Statement>>
+    where
+        Self: Sized,
+    {
+        self.clone() // TODO: check if the clone is necessary
+            .filter_map(move |statement| statement.ok().filter(|statement| pattern == statement))
+    }
+}

--- a/lib/rdf-query/src/variable.rs
+++ b/lib/rdf-query/src/variable.rs
@@ -1,7 +1,30 @@
-pub struct Variable {}
+extern crate alloc;
 
-impl core::fmt::Debug for Variable {
+use alloc::string::String;
+use rdf_model::{HeapTerm, Term};
+
+pub type Variable = GenericVariable<HeapTerm>;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub struct GenericVariable<T: Term> {
+    name: String,
+    value: Option<T>,
+}
+
+impl<T: Term> GenericVariable<T> {
+    pub fn new(name: impl Into<String>, value: Option<T>) -> Self {
+        Self {
+            name: name.into(),
+            value,
+        }
+    }
+}
+
+impl<T: Term + core::fmt::Debug> core::fmt::Debug for GenericVariable<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("Variable").finish()
+        f.debug_struct("Variable")
+            .field("name", &self.name)
+            .field("value", &self.value)
+            .finish()
     }
 }

--- a/lib/rdf-query/src/variable.rs
+++ b/lib/rdf-query/src/variable.rs
@@ -1,26 +1,50 @@
 extern crate alloc;
 
-use alloc::string::String;
-use rdf_model::{HeapTerm, Term};
+use alloc::{boxed::Box, string::String};
+use rdf_model::Term;
 
-pub type Variable = GenericVariable<HeapTerm>;
-
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
-pub struct GenericVariable<T: Term> {
+pub struct Variable {
     name: String,
-    value: Option<T>,
+    value: Option<Box<dyn Term>>,
 }
 
-impl<T: Term> GenericVariable<T> {
-    pub fn new(name: impl Into<String>, value: Option<T>) -> Self {
+impl Variable {
+    pub fn bound(name: impl Into<String>, value: impl Term + 'static) -> Self {
         Self {
             name: name.into(),
-            value,
+            value: Some(Box::new(value)),
+        }
+    }
+
+    pub fn unbound(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: None,
         }
     }
 }
 
-impl<T: Term + core::fmt::Debug> core::fmt::Debug for GenericVariable<T> {
+impl PartialEq for Variable {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Eq for Variable {}
+
+impl PartialOrd for Variable {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        self.name.partial_cmp(&other.name)
+    }
+}
+
+impl Ord for Variable {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+impl core::fmt::Debug for Variable {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("Variable")
             .field("name", &self.name)

--- a/lib/rdf-query/src/variable.rs
+++ b/lib/rdf-query/src/variable.rs
@@ -22,6 +22,10 @@ impl Variable {
             value: None,
         }
     }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 impl PartialEq for Variable {
@@ -41,6 +45,12 @@ impl PartialOrd for Variable {
 impl Ord for Variable {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.name.cmp(&other.name)
+    }
+}
+
+impl From<&str> for Variable {
+    fn from(name: &str) -> Self {
+        Variable::unbound(name)
     }
 }
 

--- a/lib/rdf-query/src/variable.rs
+++ b/lib/rdf-query/src/variable.rs
@@ -1,0 +1,7 @@
+pub struct Variable {}
+
+impl core::fmt::Debug for Variable {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Variable").finish()
+    }
+}

--- a/lib/rdf-reader/src/providers/oxrdf.rs
+++ b/lib/rdf-reader/src/providers/oxrdf.rs
@@ -45,7 +45,14 @@ impl<R: Read> Reader for OxrdfReader<R> {
 
 impl<R: Read> Source for OxrdfReader<R> {}
 
-impl<R: Read> Enumerable for OxrdfReader<R> {}
+impl<R: Read> Enumerable for OxrdfReader<R> {
+    fn grep(&self, pattern: &impl PartialEq<Box<dyn Statement>>) -> Self
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+}
 
 impl<R: Read> Countable for OxrdfReader<R> {
     fn count(&self) -> usize {


### PR DESCRIPTION
I am working on the basic functionalities of the query module. My idea is to write a definition of the structs that is as generic as possible, so that it can be used in any implementation of the Term trait. I am trying to respect as much as I can the original Ruby implementation, but I am having some issues with the fact that Ruby is dynamically typed. That's why we have introduced the Matcher struct, as Rust does not support Symbols (SPARQL query variables) and `nil` (the wildcard), and Pattern does not implement the Statement trait (term matchers can be variables).

Apart from that, let me know if I should modify this basic implementation before committing into the implementation of more complex methods.